### PR TITLE
Using dynamic imports

### DIFF
--- a/src/lib/BabylonSvelte/BabylonCamera.svelte
+++ b/src/lib/BabylonSvelte/BabylonCamera.svelte
@@ -4,18 +4,18 @@
 	const { getScene } = getContext('BabylonScene');
 	const scene = getScene();
 
-	let camera: BABYLON.FreeCamera;
+	let camera: import('babylonjs').FreeCamera;
 
 	export let name: string = null;
 	$: if (name && camera) camera.name = name;
 
-	export let position: BABYLON.Vector3 = null;
+	export let position: import('babylonjs').Vector3 = null;
 	$: if (position && camera) camera.position = position;
 
-	export let target: BABYLON.Vector3 = null;
+	export let target: import('babylonjs').Vector3 = null;
 	$: if (target && camera) camera.setTarget(target);
 
-	let BABYLON;
+	let BABYLON: Record<string, unknown>;
 
 	$: if (BABYLON && $scene && !camera) {
 		if (!name) name = '';

--- a/src/lib/BabylonSvelte/BabylonCamera.svelte
+++ b/src/lib/BabylonSvelte/BabylonCamera.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
-	import { getContext, onDestroy } from 'svelte';
-	import type { Writable } from 'svelte/store';
-
-	import * as BABYLON from 'babylonjs';
+	import { getContext, onMount, onDestroy } from 'svelte';
 
 	const { getScene } = getContext('BabylonScene');
-	const scene: Writable<BABYLON.Scene> = getScene();
+	const scene = getScene();
 
 	let camera: BABYLON.FreeCamera;
 
@@ -18,7 +15,9 @@
 	export let target: BABYLON.Vector3 = null;
 	$: if (target && camera) camera.setTarget(target);
 
-	$: if ($scene && !camera) {
+	let BABYLON;
+
+	$: if (BABYLON && $scene && !camera) {
 		if (!name) name = '';
 		if (!position) position = new BABYLON.Vector3(0, 0, 0);
 		if (!target) target = new BABYLON.Vector3(0, 0, 0);
@@ -28,6 +27,11 @@
 		const canvas = $scene.getEngine().getRenderingCanvas();
 		camera.attachControl(canvas, true);
 	}
+
+	onMount(async () => {
+		const babylonjs = await import('babylonjs');
+		BABYLON = babylonjs.default;
+	});
 
 	onDestroy(() => {
 		if ($scene && camera) $scene.removeCamera(camera);

--- a/src/lib/BabylonSvelte/BabylonEngine.svelte
+++ b/src/lib/BabylonSvelte/BabylonEngine.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
-	import { onDestroy, setContext } from 'svelte';
+	import { setContext, onMount, onDestroy } from 'svelte';
 	import { writable } from 'svelte/store';
-
-	import * as BABYLON from 'babylonjs';
 
 	let canvas: HTMLCanvasElement;
 
@@ -14,9 +12,16 @@
 		getEngine: () => engineStore
 	});
 
-	$: if (!engine && canvas) {
+	let BABYLON;
+
+	$: if (BABYLON && canvas && !engine) {
 		engine = new BABYLON.Engine(canvas, true, { preserveDrawingBuffer: true, stencil: true });
 	}
+
+	onMount(async () => {
+		const babylonjs = await import('babylonjs');
+		BABYLON = babylonjs.default;
+	});
 
 	onDestroy(() => {
 		if (engine) engine.stopRenderLoop();

--- a/src/lib/BabylonSvelte/BabylonEngine.svelte
+++ b/src/lib/BabylonSvelte/BabylonEngine.svelte
@@ -4,7 +4,7 @@
 
 	let canvas: HTMLCanvasElement;
 
-	let engine: BABYLON.Engine;
+	let engine: import('babylonjs').Engine;
 	const engineStore = writable(engine);
 	$: $engineStore = engine; // eslint-disable-line @typescript-eslint/no-unused-vars
 
@@ -12,7 +12,7 @@
 		getEngine: () => engineStore
 	});
 
-	let BABYLON;
+	let BABYLON: Record<string, unknown>;
 
 	$: if (BABYLON && canvas && !engine) {
 		engine = new BABYLON.Engine(canvas, true, { preserveDrawingBuffer: true, stencil: true });

--- a/src/lib/BabylonSvelte/BabylonGround.svelte
+++ b/src/lib/BabylonSvelte/BabylonGround.svelte
@@ -1,23 +1,27 @@
 <script lang="ts">
-	import { getContext, onDestroy } from 'svelte';
-	import type { Writable } from 'svelte/store';
-
-	import * as BABYLON from 'babylonjs';
+	import { getContext, onMount, onDestroy } from 'svelte';
 
 	const { getScene } = getContext('BabylonScene');
-	const scene: Writable<BABYLON.Scene> = getScene();
+	const scene = getScene();
 
 	let ground: BABYLON.Mesh;
 
 	export let name: string = null;
 	export let options: Record<string, unknown> = null;
 
-	$: if ($scene && !ground) {
+	let BABYLON;
+
+	$: if (BABYLON && $scene && !ground) {
 		if (!name) name = '';
 		if (!options) options = {};
 
 		ground = BABYLON.MeshBuilder.CreateGround(name, options, $scene);
 	}
+
+	onMount(async () => {
+		const babylonjs = await import('babylonjs');
+		BABYLON = babylonjs.default;
+	});
 
 	onDestroy(() => {
 		if ($scene && ground) $scene.removeMesh(ground);

--- a/src/lib/BabylonSvelte/BabylonGround.svelte
+++ b/src/lib/BabylonSvelte/BabylonGround.svelte
@@ -4,12 +4,12 @@
 	const { getScene } = getContext('BabylonScene');
 	const scene = getScene();
 
-	let ground: BABYLON.Mesh;
+	let ground: import('babylonjs').Mesh;
 
 	export let name: string = null;
 	export let options: Record<string, unknown> = null;
 
-	let BABYLON;
+	let BABYLON: Record<string, unknown>;
 
 	$: if (BABYLON && $scene && !ground) {
 		if (!name) name = '';

--- a/src/lib/BabylonSvelte/BabylonHemisphericLight.svelte
+++ b/src/lib/BabylonSvelte/BabylonHemisphericLight.svelte
@@ -4,18 +4,18 @@
 	const { getScene } = getContext('BabylonScene');
 	const scene = getScene();
 
-	let light: BABYLON.HemisphericLight;
+	let light: import('babylonjs').HemisphericLight;
 
 	export let name = '';
 	$: if (name && light) light.name = name;
 
-	export let direction: BABYLON.Vector3;
+	export let direction: import('babylonjs').Vector3;
 	$: if (direction && light) light.direction = direction;
 
 	export let intensity: number;
 	$: if (intensity && light) light.intensity = intensity;
 
-	let BABYLON;
+	let BABYLON: Record<string, unknown>;
 
 	$: if (BABYLON && $scene && !light) {
 		if (!direction) direction = new BABYLON.Vector3(0, 0, 0);

--- a/src/lib/BabylonSvelte/BabylonHemisphericLight.svelte
+++ b/src/lib/BabylonSvelte/BabylonHemisphericLight.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
-	import { getContext, onDestroy } from 'svelte';
-	import type { Writable } from 'svelte/store';
-
-	import * as BABYLON from 'babylonjs';
+	import { getContext, onMount, onDestroy } from 'svelte';
 
 	const { getScene } = getContext('BabylonScene');
-	const scene: Writable<BABYLON.Scene> = getScene();
+	const scene = getScene();
 
 	let light: BABYLON.HemisphericLight;
 
@@ -18,12 +15,19 @@
 	export let intensity: number;
 	$: if (intensity && light) light.intensity = intensity;
 
-	$: if ($scene && !light) {
+	let BABYLON;
+
+	$: if (BABYLON && $scene && !light) {
 		if (!direction) direction = new BABYLON.Vector3(0, 0, 0);
 		if (!intensity) intensity = 1.0;
 
 		light = new BABYLON.HemisphericLight(name, direction, $scene);
 	}
+
+	onMount(async () => {
+		const babylonjs = await import('babylonjs');
+		BABYLON = babylonjs.default;
+	});
 
 	onDestroy(() => {
 		if ($scene && light) $scene.removeLight(light);

--- a/src/lib/BabylonSvelte/BabylonScene.svelte
+++ b/src/lib/BabylonSvelte/BabylonScene.svelte
@@ -2,7 +2,7 @@
 	import { setContext, getContext, onMount, onDestroy, tick } from 'svelte';
 	import { writable } from 'svelte/store';
 
-	let scene: BABYLON.Scene;
+	let scene: import('babylonjs').Scene;
 	let sceneStore = writable(scene);
 	$: $sceneStore = scene; // eslint-disable-line @typescript-eslint/no-unused-vars
 
@@ -17,7 +17,7 @@
 		scene.render();
 	}
 
-	let BABYLON;
+	let BABYLON: Record<string, unknown>;
 
 	$: if (BABYLON && $engine && !scene) {
 		scene = new BABYLON.Scene($engine);

--- a/src/lib/BabylonSvelte/BabylonScene.svelte
+++ b/src/lib/BabylonSvelte/BabylonScene.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
-	import { getContext, onDestroy, setContext, tick } from 'svelte';
+	import { setContext, getContext, onMount, onDestroy, tick } from 'svelte';
 	import { writable } from 'svelte/store';
-	import type { Writable } from 'svelte/store';
-
-	import * as BABYLON from 'babylonjs';
 
 	let scene: BABYLON.Scene;
 	let sceneStore = writable(scene);
@@ -14,13 +11,15 @@
 	});
 
 	const { getEngine } = getContext('BabylonEngine');
-	const engine: Writable<BABYLON.Engine> = getEngine();
+	const engine = getEngine();
 
 	function renderFunction() {
 		scene.render();
 	}
 
-	$: if ($engine && !scene) {
+	let BABYLON;
+
+	$: if (BABYLON && $engine && !scene) {
 		scene = new BABYLON.Scene($engine);
 
 		$engine.runRenderLoop(renderFunction);
@@ -35,6 +34,11 @@
 			$engine.resize();
 		});
 	}
+
+	onMount(async () => {
+		const babylonjs = await import('babylonjs');
+		BABYLON = babylonjs.default;
+	});
 
 	onDestroy(() => {
 		if ($engine && scene) $engine.stopRenderLoop(renderFunction);

--- a/src/lib/BabylonSvelte/BabylonSphere.svelte
+++ b/src/lib/BabylonSvelte/BabylonSphere.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
-	import { getContext, onDestroy } from 'svelte';
-	import type { Writable } from 'svelte/store';
-
-	import * as BABYLON from 'babylonjs';
+	import { getContext, onMount, onDestroy } from 'svelte';
 
 	const { getScene } = getContext('BabylonScene');
-	const scene: Writable<BABYLON.Scene> = getScene();
+	const scene = getScene();
 
 	let sphere: BABYLON.Mesh;
 
@@ -16,13 +13,20 @@
 	export let position: BABYLON.Vector3 = null;
 	$: if (sphere) sphere.position = position;
 
-	$: if ($scene && !sphere) {
+	let BABYLON;
+
+	$: if (BABYLON && $scene && !sphere) {
 		if (!name) name = '';
 		if (!options) options = {};
 		if (!position) position = new BABYLON.Vector3(0, 0, 0);
 
 		sphere = BABYLON.MeshBuilder.CreateSphere(name, options, $scene);
 	}
+
+	onMount(async () => {
+		const babylonjs = await import('babylonjs');
+		BABYLON = babylonjs.default;
+	});
 
 	onDestroy(() => {
 		if ($scene && sphere) $scene.removeMesh(sphere);

--- a/src/lib/BabylonSvelte/BabylonSphere.svelte
+++ b/src/lib/BabylonSvelte/BabylonSphere.svelte
@@ -4,16 +4,16 @@
 	const { getScene } = getContext('BabylonScene');
 	const scene = getScene();
 
-	let sphere: BABYLON.Mesh;
+	let sphere: import('babylonjs').Mesh;
 
 	export let name: string = null;
 
 	export let options: Record<string, unknown> = null;
 
-	export let position: BABYLON.Vector3 = null;
+	export let position: import('babylonjs').Vector3 = null;
 	$: if (sphere) sphere.position = position;
 
-	let BABYLON;
+	let BABYLON: Record<string, unknown>;
 
 	$: if (BABYLON && $scene && !sphere) {
 		if (!name) name = '';

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -19,10 +19,10 @@
 	});
 	$t = 1;
 
-	let spherePosition;
+	let spherePosition: import('babylonjs').Vector3;
 	$: if (spherePosition) spherePosition.y = $t; // Reactively changing the Babylon sphere's y-position with our Svelte Tween
 
-	let BABYLON;
+	let BABYLON: Record<string, unknown>;
 
 	onMount(async () => {
 		const babylonjs = await import('babylonjs');


### PR DESCRIPTION
Need to figure out how to supply types when the module is dynamically imported.

```
<script lang="ts">
    import { onMount } from 'svelte';

    let BABYLON;

    let position: BABYLON.Vector3; // errors

    onMount(async () => {
        const babylonjs = await import('babylonjs');
        BABYLON = babylonjs.default;
    });
</script>
```

If i do import type * as BABYLON from 'babylonjs', I'll get re-declaration errors.
